### PR TITLE
[Bug Fix] buckets.getAcl default value

### DIFF
--- a/ql/src/security/Terraform/AWS/S3/PublicBucket/PublicBucket.ql
+++ b/ql/src/security/Terraform/AWS/S3/PublicBucket/PublicBucket.ql
@@ -16,9 +16,6 @@ import hcl
 
 from AWS::S3Bucket buckets
 where
-  // Default is public
-  not exists(buckets.getAcl())
-  or
   // Check for public-read
   buckets.getAclValue() = "public-read"
 select buckets, "Public S3 Bucket resource"

--- a/ql/test/queries-tests/Terraform/AWS/S3/PublicBucket/PublicBucket.expected
+++ b/ql/test/queries-tests/Terraform/AWS/S3/PublicBucket/PublicBucket.expected
@@ -1,3 +1,2 @@
 | S3-new.hcl:11:1:13:1 | resource aws_s3_bucket example2 | Public S3 Bucket resource |
-| S3-old.hcl:1:1:3:1 | resource aws_s3_bucket data1 | Public S3 Bucket resource |
 | S3-old.hcl:5:1:9:1 | resource aws_s3_bucket data2 | Public S3 Bucket resource |


### PR DESCRIPTION
Thank you for watching my PR.

I fixed `tf/aws/storage-publicly-accessible` because of `aws_s3_bucket.acl` default value is `private`.

### Reference

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acl