### PR TITLE
feat(iac): Update Dependencies and add better Semver support

### DIFF
--- a/ql/lib/codeql/iac/Dependencies.qll
+++ b/ql/lib/codeql/iac/Dependencies.qll
@@ -1,14 +1,40 @@
+/**
+ * Dependencies module for Infrastructure as Code languages.
+ */
 private import codeql.Locations
 private import codeql.hcl.Terraform
 
 /**
  * Dependency for all Infrastructure as Code languages.
  */
-class Dependency extends Location {
+abstract class Dependency extends Location {
+  /**
+   * Gets the name of the dependency.
+   */
+  abstract string getName();
+  /**
+   * Gets the version of the dependency (in a format that is human-readable).
+   */
+  abstract string getVersion();
+  /**
+   * Gets the raw version of the dependency (in a format that is machine-readable).
+   */
+  abstract string getRawVersion();
+  /**
+   * Gets the semantic version of the dependency.
+   */
+  abstract SemanticVersion getSemanticVersion();
+}
+
+
+/**
+ * Dependency for Terraform.
+ */
+class TerraformDependency extends Dependency {
   string name;
   string version;
 
-  Dependency() {
+  TerraformDependency() {
     // Terraform Provider
     exists(Terraform::Terraform tf, Terraform::RequiredProvider rp | rp = tf.getRequiredProvider() |
       this = rp.getLocation() and
@@ -19,25 +45,15 @@ class Dependency extends Location {
 
   override string toString() { result = this.getName() + "@" + this.getVersion() }
 
-  /**
-   * Gets the name of the dependency.
-   */
-  string getName() { result = name }
+  override string getName() { result = name }
 
-  /**
-   * Gets the version of the dependency.
-   */
-  string getVersion() { result = this.getSemanticVersion().getPretty() }
 
-  /**
-   * Gets the raw version of the dependency.
-   */
-  string getRawVersion() { result = version }
+  override string getVersion() { result = this.getSemanticVersion().getPretty() }
 
-  /**
-   * Gets the semantic version of the dependency.
-   */
-  SemanticVersion getSemanticVersion() { result = version  }
+
+  override string getRawVersion() { result = version }
+
+  override SemanticVersion getSemanticVersion() { result = version  }
 }
 
 class SemanticVersion extends string {

--- a/ql/lib/codeql/iac/Dependencies.qll
+++ b/ql/lib/codeql/iac/Dependencies.qll
@@ -27,13 +27,89 @@ class Dependency extends Location {
   /**
    * Gets the version of the dependency.
    */
-  string getVersion() { result = version.replaceAll("=", "") }
+  string getVersion() { result = this.getSemanticVersion().getPretty() }
 
-  SemanticVersion getSemanticVersion() { result = this.getVersion() }
+  /**
+   * Gets the raw version of the dependency.
+   */
+  string getRawVersion() { result = version }
+
+  /**
+   * Gets the semantic version of the dependency.
+   */
+  SemanticVersion getSemanticVersion() { result = version  }
 }
 
 class SemanticVersion extends string {
-  private Dependency dep;
+  Dependency dep;
+  string normalized;
+  string pretty;
 
-  SemanticVersion() { this = dep.getVersion() }
+  SemanticVersion() {
+    this = dep.getRawVersion() and
+    normalized = normalizeSemver(this) and 
+    pretty = prettySemver(this)
+  }
+
+  /**
+   * Holds if this version may be before `last`.
+   */
+  bindingset[last]
+  predicate maybeBefore(string last) { normalized < normalizeSemver(last) }
+
+  /**
+   * Holds if this version may be after `first`.
+   */
+  bindingset[first]
+  predicate maybeAfter(string first) { normalizeSemver(first) < normalized }
+
+  /**
+   * Holds if this version may be between `first` (inclusive) and `last` (exclusive).
+   */
+  bindingset[first, last]
+  predicate maybeBetween(string first, string last) {
+    normalizeSemver(first) <= normalized and
+    normalized < normalizeSemver(last)
+  }
+
+  /**
+   * Holds if this version is equivalent to `other`.
+   */
+  bindingset[other]
+  predicate is(string other) { normalized = normalizeSemver(other) }
+
+  string getPretty() { result = pretty }
+}
+
+bindingset[str]
+private string leftPad(string str) { result = ("000" + str).suffix(str.length()) }
+
+/**
+ * Normalizes a SemVer string such that the lexicographical ordering
+ * of two normalized strings is consistent with the SemVer ordering.
+ *
+ * Pre-release information and build metadata is not yet supported.
+ */
+bindingset[orig]
+private string normalizeSemver(string orig) {
+  exists(string pattern, string major, string minor, string patch |
+    pattern = "(=|~>|^)(\\d+)\\.(\\d+)\\.(\\d+)" and
+    major = orig.regexpCapture(pattern, 2) and
+    minor = orig.regexpCapture(pattern, 3) and
+    patch = orig.regexpCapture(pattern, 4)
+  |
+    result = leftPad(major) + "." + leftPad(minor) + "." + leftPad(patch)
+  )
+}
+
+bindingset[orig]
+private string prettySemver(string orig) {
+  exists(string pattern, string major, string minor, string patch |
+    pattern = "(=|~>|^)(\\d+)\\.(\\d+)\\.(\\d+)" and
+    major = orig.regexpCapture(pattern, 2) and
+    minor = orig.regexpCapture(pattern, 3) and
+    patch = orig.regexpCapture(pattern, 4)
+  |
+    result = major + "." + minor + "." + patch
+  )
 }

--- a/ql/test/library-tests/hcl/terraform/Dependencies.expected
+++ b/ql/test/library-tests/hcl/terraform/Dependencies.expected
@@ -1,3 +1,6 @@
+dependencies
 | providers.tf:5:15:8:5 | hashicorp/azurerm@3.0.0 |
 | providers.tf:9:14:9:22 | hashicorp/time@~>0.7.2 |
 | providers.tf:10:14:10:22 | hashicorp/random@~>3.3.1 |
+semver
+| 3.0.0 |

--- a/ql/test/library-tests/hcl/terraform/Dependencies.expected
+++ b/ql/test/library-tests/hcl/terraform/Dependencies.expected
@@ -1,6 +1,8 @@
 dependencies
 | providers.tf:5:15:8:5 | hashicorp/azurerm@3.0.0 |
-| providers.tf:9:14:9:22 | hashicorp/time@~>0.7.2 |
-| providers.tf:10:14:10:22 | hashicorp/random@~>3.3.1 |
+| providers.tf:9:14:9:22 | hashicorp/time@0.7.2 |
+| providers.tf:10:14:10:22 | hashicorp/random@3.3.1 |
 semver
-| 3.0.0 |
+| providers.tf:5:15:8:5 | hashicorp/azurerm@3.0.0 | =3.0.0 |
+| providers.tf:9:14:9:22 | hashicorp/time@0.7.2 | ~>0.7.2 |
+| providers.tf:10:14:10:22 | hashicorp/random@3.3.1 | ~>3.3.1 |

--- a/ql/test/library-tests/hcl/terraform/Dependencies.ql
+++ b/ql/test/library-tests/hcl/terraform/Dependencies.ql
@@ -1,3 +1,5 @@
 import hcl
 
 query predicate dependencies(Dependency d) { any() }
+
+query predicate semver(Dependency d, SemanticVersion v) { d.getSemanticVersion() = v }


### PR DESCRIPTION
### Improvements to Dependency and SemanticVersion classes:

* [`ql/lib/codeql/iac/Dependencies.qll`](diffhunk://#diff-3f801666ab60b847c34ba591c86f97198b57e9f095194bac3071a6b3ad9a9251L30-R114): Modified the `Dependency` class to use `getSemanticVersion().getPretty()` for fetching version information and added methods to retrieve raw and semantic versions. Enhanced the `SemanticVersion` class with new properties and predicates for better version comparison and normalization.

### Updates to test files:

* [`ql/test/library-tests/hcl/terraform/Dependencies.expected`](diffhunk://#diff-ab51cd8b1453bb24ad2a841d72ccfe4892a84389c7c8b55a8295024736ed9b9aR1-R6): Added new entries to test the semantic versioning of dependencies.
* [`ql/test/library-tests/hcl/terraform/Dependencies.ql`](diffhunk://#diff-5ab8853ef60bdf05dc5fd5170e57b7e2a206ba1fd67a1fc9e5c1e82f657617bbR4-R5): Introduced a new query predicate `semver` to validate the semantic versioning functionality.