### PR TITLE
fix: use the correct env var for this extractor

### DIFF
--- a/tools/pre-finalize.cmd
+++ b/tools/pre-finalize.cmd
@@ -9,6 +9,6 @@ type NUL && "%CODEQL_DIST%\codeql" database index-files ^
     --size-limit=5m ^
     --language yaml ^
     -- ^
-    "%CODEQL_EXTRACTOR_QL_WIP_DATABASE%"
+    "%CODEQL_EXTRACTOR_IAC_WIP_DATABASE%"
 
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
Use the [correct env var](https://github.com/advanced-security/codeql-extractor-iac/blob/1709e321895e42d5b3cc1c4047ce4fc70639ad95/extractor/src/autobuilder.rs#L13) in pre-finalize.cmd