### PR TITLE
ci: update Patch Release Me to digest-pinned 0.6.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,11 @@ jobs:
         uses: actions/checkout@v6.0.3
 
       - name: "Patch Release Me"
-        uses: 42ByteLabs/patch-release-me@04ea0a696abfc3cfbdfadb279bd9c9dd0b1652a2    # 0.6.6
+        # TODO: Return to the upstream action after its runtime image is digest-pinned:
+        # https://github.com/42ByteLabs/patch-release-me/issues/169
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
         with:
-          mode: ${{ github.event.inputs.bump }}
+          args: bump -m ${{ github.event.inputs.bump }}
 
       - name: "Bundle"
         run: |


### PR DESCRIPTION
## Summary

- Replace the unusable Patch Release Me 0.6.6 action reference with the published 0.6.7 container image.
- Pin the OCI image-index digest and pass the bump mode through the Docker action `args` input.
- Document returning to the repository action after 42ByteLabs/patch-release-me#169 is resolved.

## Why

The 0.6.6 container image was never published. Version 0.6.7 restores the image and fixes mode argument handling.

Using `docker://...:0.6.7@sha256:...` also pins the executed container bytes. The repository action is not used yet because its Dockerfile still references a mutable image tag.

## Validation

- Parsed the updated workflow as YAML.
- Ran `git diff --check`.
- Resolved the 0.6.7 OCI image-index digest with `docker buildx imagetools inspect`.
